### PR TITLE
Align frontend unit test with current layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ npm run dev
    - All placeholder pages show "Under Construction" message
 5. All data is persisted in PostgreSQL with pgvector extension
 
+### **Running Unit Tests**
+
+```bash
+# Backend
+cd backend
+python -m pytest
+
+# Frontend
+cd frontend
+npm run test:unit
+```
+
 ---
 
 ## **Technical Architecture**

--- a/frontend/src/__tests__/App.spec.ts
+++ b/frontend/src/__tests__/App.spec.ts
@@ -4,8 +4,8 @@ import { mount } from '@vue/test-utils'
 import App from '../App.vue'
 
 describe('App', () => {
-  it('mounts renders properly', () => {
+  it('renders main layout', () => {
     const wrapper = mount(App)
-    expect(wrapper.text()).toContain('You did it!')
+    expect(wrapper.text()).toContain('AI Testing Standard Platform')
   })
 })


### PR DESCRIPTION
## Summary
- update App unit test to match current dashboard text
- document how to run backend and frontend tests

## Testing
- `python -m pytest`
- `npm run test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c039f7a39c83269c5dcecfd1cd284e